### PR TITLE
Improve nested benchmark API

### DIFF
--- a/test/lib/worker_test.rb
+++ b/test/lib/worker_test.rb
@@ -59,6 +59,14 @@ module Sidekiq
           end
         end
 
+        it "should allow benchmark methods" do
+          worker = AlterWorkerMock.new
+          value  = worker.benchmark.call(:multiply, 4, 4)
+
+          value.must_equal 16
+          worker.benchmark.metrics[:multiply].wont_be_nil
+        end
+
       end
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -64,6 +64,10 @@ module Sidekiq
           @metric_names = [:test_metric, :other_metric]
         end
 
+        def multiply(a, b)
+          a * b
+        end
+
         def finish
           benchmark.finish
         end


### PR DESCRIPTION
API is 100% compatible with original one, and extend it with 3 new methods:
- `Benchmark#[]` returns nested timing report
- `Benchmark#[]=` privides a clean API to set timing value
- `Benchmark#measure` benchmarks given block

USAGE:

``` ruby
  class ArticleElesticUpdater
    def perform(operation, id)
      send(operation, id)
    end

    def update(id)
      benchmark do |bm|
        article = bm.measure(:find_article) { Article.find id }
        bm.measure(:update_index) { article.update_elastic_index }
      end
    end

    def delete(id)
      benchmark do |bm|
        bm.measure(:delete_index) { Article.delete_elastic_index id }
      end
    end
  end
```
