### PR TITLE
When used in Production, JS wasn't loading

### DIFF
--- a/lib/sidekiq-benchmark/web.rb
+++ b/lib/sidekiq-benchmark/web.rb
@@ -13,8 +13,6 @@ module Sidekiq
 
         app.assets {
           serve '/js', from: js_dir
-
-          js 'chartkick', ['/js/chartkick.js']
         }
 
         app.get "/benchmarks" do

--- a/web/views/benchmarks.erb
+++ b/web/views/benchmarks.erb
@@ -1,5 +1,5 @@
 <script type="text/javascript" src="//www.google.com/jsapi"></script>
-<%= js :chartkick %>
+<script type="text/javascript" src="<%= root_path %>js/chartkick.js"></script>
 
 <header class="row">
   <div class="col-md-6">


### PR DESCRIPTION
There seems to be a problem using this with a Rails app in `production`; everything is fine in `development` and `staging` but in production the `chartkick.js` file was served as an empty file but with a 200, resulting in no graphs :frowning:. This looks like a result of a misconfig of the Sinatra asset pipeline? This branch uses a simplified strategy which is working happily in Production.

(Graphs are awesome)